### PR TITLE
[config] ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ rebar3.crashdump
 logs
 *.a
 *.so
+compile_commands.json


### PR DESCRIPTION
Use build_c_db.sh to generate `compile_commands.json'